### PR TITLE
Parses gs:// urls correctly now.

### DIFF
--- a/zipfile/provider.go
+++ b/zipfile/provider.go
@@ -95,10 +95,7 @@ func FromURL(ctx context.Context, u *url.URL) (Provider, error) {
 	switch u.Scheme {
 	case "gs":
 		client, err := storage.NewClient(ctx)
-		filename := u.Path
-		if strings.HasPrefix(filename, "/") {
-			filename = filename[1:]
-		}
+		filename := strings.TrimPrefix(u.Path, "/")
 		if len(filename) == 0 {
 			return nil, errors.New("Bad GS url, no filename detected")
 		}


### PR DESCRIPTION
Also eliminates a bug where the md5 might not encode to a valid UTF8 string to use as a prometheus label

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/uuid-annotator/6)
<!-- Reviewable:end -->
