### PR TITLE
Fix enumeration of local interface IPs

### DIFF
--- a/annotator/annotator.go
+++ b/annotator/annotator.go
@@ -20,9 +20,10 @@ var (
 
 // Annotations contains the standard columns we would like to add as annotations for every UUID.
 type Annotations struct {
-	UUID           string
-	Timestamp      time.Time
-	Server, Client api.Annotations
+	UUID      string
+	Timestamp time.Time
+	Server    api.Annotations `bigquery:"server"` // Use Standard Top-Level Column names.
+	Client    api.Annotations `bigquery:"client"` // Use Standard Top-Level Column names.
 }
 
 // Annotator is the interface that all systems that want to add metadata should implement.

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -69,6 +69,7 @@ func (h *handler) annotateAndSave(j *job) {
 	for _, ann := range h.annotators {
 		err := ann.Annotate(j.id, annotations)
 		if err != nil {
+			log.Println(err)
 			metrics.AnnotationErrors.Inc()
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"log"
 	"net"
 	"net/url"
 	"sync"
@@ -40,6 +41,10 @@ var (
 	mainCtx, mainCancel = context.WithCancel(context.Background())
 )
 
+func init() {
+	log.SetFlags(log.LstdFlags | log.LUTC | log.Lshortfile)
+}
+
 func main() {
 	flag.Parse()
 	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Could not get args from environment variables")
@@ -61,7 +66,9 @@ func main() {
 	localAddrs, err := net.InterfaceAddrs()
 	localIPs := []net.IP{}
 	for _, addr := range localAddrs {
-		localIPs = append(localIPs, net.ParseIP(addr.String()))
+		// By default, addr.String() includes the netblock suffix. By casting to
+		// the underlying net.IPNet we can extract just the IP.
+		localIPs = append(localIPs, addr.(*net.IPNet).IP)
 	}
 	rtx.Must(err, "Could not read local addresses")
 	u, err := url.Parse(*maxmindurl)


### PR DESCRIPTION
Previously, the uuid-annotator was failing to lookup 100% IPs. This turned out to be caused by a failure to determine direction of flows in:
https://github.com/m-lab/uuid-annotator/blob/1fc8c0aa523ff58f11036503f98a9b456f40f8c1/ipannotator/ipannotator.go#L49-L68

Because it was comparing flow IPs ("4.14.5.71") to local interfaces with "<nil>" because the collection of the localIPs in main.go failed to parse the netblock format for local interface addrs.

This change casts the local interface addrs to *net.IPNet` and extracts the net.IP from within. This change also includes additional logging. And, the annotations result struct is annotated for bigquery with standard column names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/uuid-annotator/8)
<!-- Reviewable:end -->
