### PR TITLE
Enable using routeviews for ASN annotations

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/m-lab/go/flagx"
 	"github.com/m-lab/go/memoryless"
 	"github.com/m-lab/go/warnonerror"
+	"src/github.com/m-lab/uuid-annotator/asnannotator"
 
 	"github.com/m-lab/uuid-annotator/annotator"
 	"github.com/m-lab/uuid-annotator/geoannotator"
@@ -85,11 +86,11 @@ func main() {
 	rtx.Must(err, "Could not get maxmind data from url")
 	geo := geoannotator.New(mainCtx, p, localIPs)
 
-	//p4, err := rawfile.FromURL(mainCtx, routeviewv4.URL)
-	//rtx.Must(err, "Could not load routeview v4 URL")
-	//p6, err := rawfile.FromURL(mainCtx, routeviewv6.URL)
-	//rtx.Must(err, "Could not load routeview v6 URL")
-	//asn := asnannotator.New(mainCtx, p4, p6, localIPs)
+	p4, err := rawfile.FromURL(mainCtx, routeviewv4.URL)
+	rtx.Must(err, "Could not load routeview v4 URL")
+	p6, err := rawfile.FromURL(mainCtx, routeviewv6.URL)
+	rtx.Must(err, "Could not load routeview v6 URL")
+	asn := asnannotator.New(mainCtx, p4, p6, localIPs)
 
 	// Reload the IP annotation config on a randomized schedule.
 	wg.Add(1)
@@ -103,7 +104,7 @@ func main() {
 		rtx.Must(err, "Could not create ticker for reloading")
 		for range tick.C {
 			geo.Reload(mainCtx)
-			// asn.Reload(mainCtx)
+			asn.Reload(mainCtx)
 		}
 		wg.Done()
 	}()

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/m-lab/go/flagx"
 	"github.com/m-lab/go/memoryless"
 	"github.com/m-lab/go/warnonerror"
-	"src/github.com/m-lab/uuid-annotator/asnannotator"
+	"github.com/m-lab/uuid-annotator/asnannotator"
 
 	"github.com/m-lab/uuid-annotator/annotator"
 	"github.com/m-lab/uuid-annotator/geoannotator"

--- a/routeview/parse.go
+++ b/routeview/parse.go
@@ -20,17 +20,17 @@ type IPNet struct {
 	Systems string
 }
 
-// IPNetSlice is a sortable (and searchable) array of IPNets.
-type IPNetSlice []IPNet
+// Index is a sortable (and searchable) array of IPNets.
+type Index []IPNet
 
-// Len, Less, and Swap make IPNetSlice sortable.
-func (ns IPNetSlice) Len() int {
+// Len, Less, and Swap make Index sortable.
+func (ns Index) Len() int {
 	return len(ns)
 }
-func (ns IPNetSlice) Less(i, j int) bool {
+func (ns Index) Less(i, j int) bool {
 	return bytes.Compare(ns[i].IP, ns[j].IP) < 0
 }
-func (ns IPNetSlice) Swap(i, j int) {
+func (ns Index) Swap(i, j int) {
 	n := ns[j]
 	ns[j] = ns[i]
 	ns[i] = n
@@ -65,8 +65,8 @@ func ParseSystems(s string) []annotator.System {
 }
 
 // ParseRouteView reads the given csv file and generates a sorted IP list.
-func ParseRouteView(file []byte) IPNetSlice {
-	result := IPNetSlice{}
+func ParseRouteView(file []byte) Index {
+	result := Index{}
 	sm := map[string]string{}
 
 	skip := 0
@@ -105,8 +105,8 @@ func ParseRouteView(file []byte) IPNetSlice {
 // ErrNoASNFound is returned when search fails to identify a network for the given src IP.
 var ErrNoASNFound = errors.New("No ASN found for address")
 
-// Search attempts to find the given IP in the IPNetSlice.
-func (ns IPNetSlice) Search(s string) (IPNet, error) {
+// Search attempts to find the given IP in the Index.
+func (ns Index) Search(s string) (IPNet, error) {
 	// bytes.Compare will only work correctly when both net.IPs have the same byte count.
 	ip := net.ParseIP(s)
 	if ip.To4() != nil {

--- a/routeview/parse_test.go
+++ b/routeview/parse_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/m-lab/uuid-annotator/rawfile"
 )
 
-var ns IPNetSlice
+var ns Index
 var an api.Annotator
 
 func init() {


### PR DESCRIPTION
This change enables routeview ASN annotations using the `routeview.Index`. Unlike the previous version, now asn annotation only sets the annotations.Client field. The Server fields will be populated by information generated by siteinfo - https://github.com/m-lab/siteinfo/pull/113 in a following PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/uuid-annotator/19)
<!-- Reviewable:end -->
