### PR TITLE
Assign server annotations when IP is in server netblocks

### DIFF
--- a/annotator/annotator.go
+++ b/annotator/annotator.go
@@ -101,8 +101,8 @@ type ServerAnnotations struct {
 type Annotations struct {
 	UUID      string
 	Timestamp time.Time
-	Server    ServerAnnotations `bigquery:"server"` // Use Standard Top-Level Column names.
-	Client    ClientAnnotations `bigquery:"client"` // Use Standard Top-Level Column names.
+	Server    ServerAnnotations `json:",omitempty" bigquery:"server"` // Use Standard Top-Level Column names.
+	Client    ClientAnnotations `json:",omitempty" bigquery:"client"` // Use Standard Top-Level Column names.
 }
 
 // Annotator is the interface that all systems that want to add metadata should implement.

--- a/siteannotator/server.go
+++ b/siteannotator/server.go
@@ -26,9 +26,9 @@ type siteAnnotator struct {
 	v6             net.IPNet
 }
 
-// ErrNotFound is generated when the given hostname cannot be found in the
+// ErrHostnameNotFound is generated when the given hostname cannot be found in the
 // downloaded siteinfo annotations.
-var ErrNotFound = errors.New("Not Found")
+var ErrHostnameNotFound = errors.New("Hostname Not Found")
 
 // New makes a new server Annotator using metadata from siteinfo JSON.
 func New(ctx context.Context, hostname string, js rawfile.Provider, localIPs []net.IP) annotator.Annotator {
@@ -112,7 +112,7 @@ func (g *siteAnnotator) load(ctx context.Context) (*annotator.ServerAnnotations,
 	}
 	f := strings.Split(g.hostname, ".")
 	if len(f) < 2 {
-		return nil, ErrNotFound
+		return nil, ErrHostnameNotFound
 	}
 	site := f[1]
 	for i := range s {
@@ -126,5 +126,5 @@ func (g *siteAnnotator) load(ctx context.Context) (*annotator.ServerAnnotations,
 			return &result, nil
 		}
 	}
-	return nil, ErrNotFound
+	return nil, ErrHostnameNotFound
 }

--- a/siteannotator/server_test.go
+++ b/siteannotator/server_test.go
@@ -105,7 +105,7 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
-			name:     "success-empty-ipv4",
+			name:     "success-empty-ipv4-with-ipv6-connection",
 			localIPs: []net.IP{net.ParseIP("2001:5a0:4300::2")},
 			provider: localRawfile,
 			hostname: "mlab1.four0.measurement-lab.org",
@@ -120,7 +120,20 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
-			name:     "success-empty-ipv6",
+			name:     "success-empty-ipv4-with-ipv4-connection",
+			localIPs: []net.IP{net.ParseIP("64.86.148.137")},
+			provider: localRawfile,
+			hostname: "mlab1.four0.measurement-lab.org",
+			ID: &inetdiag.SockID{
+				SPort: 1,
+				SrcIP: "64.86.148.137",
+				DPort: 2,
+				DstIP: "1.0.0.1",
+			},
+			want: annotator.Annotations{},
+		},
+		{
+			name:     "success-empty-ipv6-with-ipv4-connection",
 			localIPs: []net.IP{net.ParseIP("64.86.148.130")},
 			provider: localRawfile,
 			hostname: "mlab1.six01.measurement-lab.org",
@@ -133,6 +146,19 @@ func TestNew(t *testing.T) {
 			want: annotator.Annotations{
 				Server: minimalServerAnn("six01"),
 			},
+		},
+		{
+			name:     "success-empty-ipv6-with-ipv6-connection",
+			localIPs: []net.IP{net.ParseIP("2001:5a0:4300::2")},
+			provider: localRawfile,
+			hostname: "mlab1.six01.measurement-lab.org",
+			ID: &inetdiag.SockID{
+				SPort: 1,
+				SrcIP: "2001:5a0:4300::2",
+				DPort: 2,
+				DstIP: "2600::1",
+			},
+			want: annotator.Annotations{},
 		},
 		{
 			name:     "error-neither-ips-are-server",

--- a/testdata/annotations.json
+++ b/testdata/annotations.json
@@ -1,24 +1,95 @@
 [
    {
-      "Geo": {
-         "City": "New York",
-         "ContinentCode": "NA",
-         "CountryCode": "US",
-         "Latitude": 40.7667,
-         "Longitude": -73.8667,
-         "State": "NY"
+      "Annotation": {
+         "Geo": {
+            "City": "New York",
+            "ContinentCode": "NA",
+            "CountryCode": "US",
+            "Latitude": 40.7667,
+            "Longitude": -73.8667,
+            "State": "NY"
+         },
+         "Network": {
+            "ASName": "TATA COMMUNICATIONS (AMERICA) INC",
+            "ASNumber": 6453,
+            "Systems": [
+               {
+                  "ASNs": [
+                     6453
+                  ]
+               }
+            ]
+         },
+         "Site": "lga03"
       },
+      "Name": "lga03",
       "Network": {
-         "ASName": "TATA COMMUNICATIONS (AMERICA) INC",
-         "ASNumber": 6453,
-         "Systems": [
-            {
-               "ASNs": [
-                  6453
-               ]
-            }
-         ]
+         "IPv4": "64.86.148.128/26",
+         "IPv6": "2001:5a0:4300::/64"
+      }
+   },
+   {
+      "Annotation": {
+         "Geo": {
+            "City": "New York"
+         },
+         "Network": {
+            "ASName": "TATA COMMUNICATIONS (AMERICA) INC"
+         },
+         "Site": "four0"
       },
-      "Site": "lga03"
+      "Name": "four0",
+      "Network": {
+         "IPv4": "",
+         "IPv6": "2001:5a0:4300::/64"
+      }
+   },
+   {
+      "Annotation": {
+         "Geo": {
+            "City": "New York"
+         },
+         "Network": {
+            "ASName": "TATA COMMUNICATIONS (AMERICA) INC"
+         },
+         "Site": "six01"
+      },
+      "Name": "six01",
+      "Network": {
+         "IPv4": "64.86.148.128/26",
+         "IPv6": ""
+      }
+   },
+   {
+      "Annotation": {
+         "Geo": {
+            "City": "New York"
+         },
+         "Network": {
+            "ASName": "TATA COMMUNICATIONS (AMERICA) INC"
+         },
+         "Site": "bad04"
+      },
+      "Name": "bad04",
+      "Network": {
+         "IPv4": "this-is-not-a-subnet/26",
+         "IPv6": "2001:5a0:4300::/64"
+      }
+   },
+   {
+      "Annotation": {
+         "Geo": {
+            "City": "New York"
+         },
+         "Network": {
+            "ASName": "TATA COMMUNICATIONS (AMERICA) INC"
+         },
+         "Site": "bad06"
+      },
+      "Name": "bad06",
+      "Network": {
+         "IPv4": "64.86.148.128/26",
+         "IPv6": "this-is-not-a-subnet/64"
+      }
    }
 ]


### PR DESCRIPTION
This change updates the siteinfo struct used to import the server annotations so that it includes the ipv4 and ipv6 netblocks for the site. Assigning server annotations are now conditional on IPs being within that netblock. As a result, private IPs will not be annotated with the server annotations.

This change also adds additional test cases to `testdata/annotations.json `

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/uuid-annotator/21)
<!-- Reviewable:end -->
