### PR TITLE
Support "stand-alone" mode for uuid-annotator (conditionally tcpinfo eventsocket)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,21 @@ tcp-info, packet-headers, traceroute-caller, and DISCO. It represents our one
 chance to annotate UUIDs with metadata. As such, the health of the experiment
 service should depend on the health of the UUID annotation service, just like it
 should depend on the other core services.
+
+## Usage
+
+### Stand-alone
+
+If only the local ipservice socket is needed to provide annotations for specific
+IPs, the uuid-annotator may be run in a "stand-alone" mode. This mode does not
+require the tcp-info `-tcpinfo.eventsocket`, `-siteinfo.url`, or `-datadir`
+flags.
+
+```sh
+docker build -t local-annotator .
+docker run -v $PWD/testdata:/testdata -it local-annotator   \
+    -ipservice.sock=/local/uuid-annotator.sock \
+    -maxmind.url=file:///testdata/GeoLite2-City-real.tar.gz \
+    -routeview-v4.url=file:///testdata/RouteViewIPv4.pfx2as.gz \
+    -routeview-v6.url=file:///testdata/RouteViewIPv6.pfx2as.gz
+```

--- a/main.go
+++ b/main.go
@@ -100,10 +100,6 @@ func main() {
 	rtx.Must(err, "Could not load AS names URL")
 	asn := asnannotator.New(mainCtx, p4, p6, asnames, localIPs)
 
-	js, err := content.FromURL(mainCtx, siteinfo.URL)
-	rtx.Must(err, "Could not load siteinfo URL")
-	site := siteannotator.New(mainCtx, *hostname, js, localIPs)
-
 	// Reload the IP annotation config on a randomized schedule.
 	wg.Add(1)
 	go func() {
@@ -121,16 +117,21 @@ func main() {
 		wg.Done()
 	}()
 
-	// Generate .json files for every UUID discovered.
-	h := handler.New(*datadir, *eventbuffersize, []annotator.Annotator{geo, asn, site})
-	wg.Add(1)
-	go func() {
-		h.ProcessIncomingRequests(mainCtx)
-		wg.Done()
-	}()
-
-	// Listen to the event socket to find out about new UUIDs and then process them.
 	if *eventsocket.Filename != "" {
+		// Load the siteinfo annotations for "site" specific metadata.
+		js, err := content.FromURL(mainCtx, siteinfo.URL)
+		rtx.Must(err, "Could not load siteinfo URL")
+		site := siteannotator.New(mainCtx, *hostname, js, localIPs)
+
+		// Generate .json files for every UUID discovered.
+		h := handler.New(*datadir, *eventbuffersize, []annotator.Annotator{geo, asn, site})
+		wg.Add(1)
+		go func() {
+			h.ProcessIncomingRequests(mainCtx)
+			wg.Done()
+		}()
+
+		// Listen to the event socket to find out about new UUIDs and then process them.
 		wg.Add(1)
 		go func() {
 			eventsocket.MustRun(mainCtx, *eventsocket.Filename, h)

--- a/main.go
+++ b/main.go
@@ -130,11 +130,13 @@ func main() {
 	}()
 
 	// Listen to the event socket to find out about new UUIDs and then process them.
-	wg.Add(1)
-	go func() {
-		eventsocket.MustRun(mainCtx, *eventsocket.Filename, h)
-		wg.Done()
-	}()
+	if *eventsocket.Filename != "" {
+		wg.Add(1)
+		go func() {
+			eventsocket.MustRun(mainCtx, *eventsocket.Filename, h)
+			wg.Done()
+		}()
+	}
 
 	// Set up the local service to serve IP annotations as a local service on a
 	// local unix-domain socket.


### PR DESCRIPTION
This change starts the tcp-info eventsocket handler only if the `-tcpinfo.eventsocket` flag has been provided. By making this step conditional, the uuid-annotator may be started in a "stand-alone" mode for requests to the uuid-annotator's socket service for dynamic annotation requests without requiring tcp-info also. This makes several other flags optional when running in stand-alone mode.

The README now includes a usage example of this stand-alone mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/uuid-annotator/42)
<!-- Reviewable:end -->
