### PR TITLE
Allow annotations when the local server IP is not contained in siteinfo public IP netblock

### DIFF
--- a/siteannotator/server_test.go
+++ b/siteannotator/server_test.go
@@ -115,7 +115,7 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
-			name:     "success-empty-ipv4-with-ipv6-connection",
+			name:     "success-no-ipv4-config-with-ipv6-connection",
 			localIPs: []net.IP{net.ParseIP("2001:5a0:4300::2")},
 			provider: &localRawfile,
 			hostname: "mlab1.six02.measurement-lab.org",
@@ -130,7 +130,7 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
-			name:     "success-empty-ipv4-with-ipv4-connection",
+			name:     "success-no-ipv4-config-with-ipv4-connection",
 			localIPs: []net.IP{net.ParseIP("64.86.148.137")},
 			provider: &localRawfile,
 			hostname: "mlab1.six02.measurement-lab.org",
@@ -143,7 +143,7 @@ func TestNew(t *testing.T) {
 			want: annotator.Annotations{},
 		},
 		{
-			name:     "success-empty-ipv6-with-ipv4-connection",
+			name:     "success-no-ipv6-config-with-ipv4-connection",
 			localIPs: []net.IP{net.ParseIP("64.86.148.130")},
 			provider: &localRawfile,
 			hostname: "mlab1.six01.measurement-lab.org",
@@ -158,7 +158,7 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
-			name:     "success-empty-ipv6-with-ipv6-connection",
+			name:     "success-no-ipv6-config-with-ipv6-connection",
 			localIPs: []net.IP{net.ParseIP("2001:5a0:4300::2")},
 			provider: &localRawfile,
 			hostname: "mlab1.six01.measurement-lab.org",


### PR DESCRIPTION
This change updates the uuid-annotator logic to be more permissive for siteinfo annotations when the local IP is not contained in the siteinfo public IP netblock. This can occur when deployments to GCE VMs have a public IP  registered with siteinfo but the uuid-annotator only knows about the local private server IP. With this change, rather than checking that the source IP is contained within the siteinfo netblock, we accept that the local IP *is* the server IP and annotate using the siteinfo annotations, using the appropriate ipv4 or ipv6 address. If there is no registered IPv4 or IPv6 netblock in siteinfo then no annotation is recorded.

Fixes #43

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/uuid-annotator/44)
<!-- Reviewable:end -->
