### PR TITLE
Use the m-lab/go/host package to parse -hostname flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/go-test/deep v1.0.6
 	github.com/m-lab/annotation-service v0.0.0-20210504151333-138bdf572368
-	github.com/m-lab/go v0.1.47
+	github.com/m-lab/go v0.1.57
 	github.com/m-lab/tcp-info v1.5.3
 	github.com/oschwald/geoip2-golang v1.7.0
 	github.com/prometheus/client_golang v1.12.2

--- a/go.sum
+++ b/go.sum
@@ -248,6 +248,8 @@ github.com/m-lab/annotation-service v0.0.0-20210504151333-138bdf572368 h1:cRzgLE
 github.com/m-lab/annotation-service v0.0.0-20210504151333-138bdf572368/go.mod h1:bW5A2AmUqyh6kGbmu4X8fYK2pRcfTvTjAXW/+4VQZUA=
 github.com/m-lab/go v0.1.47 h1:yV6RgVpiWm2BnpJcjfy4pbUkB9cz0BvBbVG64UGLiC0=
 github.com/m-lab/go v0.1.47/go.mod h1:woT26L9Hf07juZGHe7Z4WveV7MM6NS6vQaaWzRQnab4=
+github.com/m-lab/go v0.1.57 h1:C6IjtM/DY0FEiA3FB2HS7av4ybtwQOa8Y3vys6XEXaA=
+github.com/m-lab/go v0.1.57/go.mod h1:O1D/EoVarJ8lZt9foANcqcKtwxHatBzUxXFFyC87aQQ=
 github.com/m-lab/tcp-info v1.5.3 h1:4IspTPcNc8D8LNRvuFnID8gDiz+hxPAtYvpKZaiGGe8=
 github.com/m-lab/tcp-info v1.5.3/go.mod h1:bkvI4qbjB6QVC2tsLSHqf5OnIYcmuLEVjo7+8YA56Kg=
 github.com/m-lab/uuid-annotator v0.4.1/go.mod h1:f/zvgcc5A3HQ1Y63HWpbBVXNcsJwQ4uRIOqsF/nyto8=

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"log"
 	"net"
 	"sync"
@@ -84,7 +83,7 @@ func main() {
 	// https://siteinfo.mlab-oti.measurementlab.net/v2/sites/annotations.json
 	h, err := host.Parse(*hostname)
 	rtx.Must(err, "Failed to parse -hostname flag value")
-	mlabHostname := fmt.Sprintf("%s-%s.%s.%s", h.Machine, h.Site, h.Project, h.Domain)
+	mlabHostname := h.String()
 
 	defer mainCancel()
 	// A waitgroup that waits for every component goroutine to complete before main exits.

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"net"
 	"sync"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/m-lab/go/content"
 	"github.com/m-lab/go/flagx"
+	"github.com/m-lab/go/host"
 	"github.com/m-lab/go/memoryless"
 	"github.com/m-lab/go/prometheusx"
 	"github.com/m-lab/go/rtx"
@@ -71,6 +73,19 @@ func main() {
 	flag.Parse()
 	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Could not get args from environment variables")
 
+	// Parse the node's name into its constituent parts. This ensures that the
+	// value of the -hostname flag is actually valid. Additionally, virtual
+	// nodes which are part of a managed instance group may have a random
+	// suffix, which uuid-annotator cannot use, so we explicitly only include
+	// the parts of the node name that uuid-annotator actually cares about. The
+	// resultant variable mlabHostname should match a machine name in siteinfo's
+	// annotations.json:
+	//
+	// https://siteinfo.mlab-oti.measurementlab.net/v2/sites/annotations.json
+	h, err := host.Parse(*hostname)
+	rtx.Must(err, "Failed to parse -hostname flag value")
+	mlabHostname := fmt.Sprintf("%s-%s.%s.%s", h.Machine, h.Site, h.Project, h.Domain)
+
 	defer mainCancel()
 	// A waitgroup that waits for every component goroutine to complete before main exits.
 	wg := sync.WaitGroup{}
@@ -121,7 +136,7 @@ func main() {
 		// Load the siteinfo annotations for "site" specific metadata.
 		js, err := content.FromURL(mainCtx, siteinfo.URL)
 		rtx.Must(err, "Could not load siteinfo URL")
-		site := siteannotator.New(mainCtx, *hostname, js, localIPs)
+		site := siteannotator.New(mainCtx, mlabHostname, js, localIPs)
 
 		// Generate .json files for every UUID discovered.
 		h := handler.New(*datadir, *eventbuffersize, []annotator.Annotator{geo, asn, site})


### PR DESCRIPTION
This provides a consistent interface for processing a hostname, and allows us to handle special cases in the `host` package instead of in this code. For example, the `host` package knows about managed instance group random suffixes on instance/node names, and can handle that gracefully for uuid-annotator.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/uuid-annotator/50)
<!-- Reviewable:end -->
