### PR TITLE
Adds public IP of LB to localIPs slice

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,6 +102,17 @@ func main() {
 	localAddrs, err := net.InterfaceAddrs()
 	rtx.Must(err, "Could not read local addresses")
 	localIPs := findLocalIPs(localAddrs)
+
+	// Load the siteinfo annotations for "site" specific metadata. Additionally,
+	// if this is a virtual site, New() will append the public IP of the
+	// managed instance group's load balancer to localIPs. If uuid-annotator
+	// does not know about the public IP of the load balancer, then it will fail
+	// to annotate anything because it doesn't recognize its own public address
+	// in either the Src of Dest of incoming tcp-info events.
+	js, err := content.FromURL(mainCtx, siteinfo.URL)
+	rtx.Must(err, "Could not load siteinfo URL")
+	site, localIPs := siteannotator.New(mainCtx, mlabHostname, js, localIPs)
+
 	p, err := content.FromURL(mainCtx, maxmindurl.URL)
 	rtx.Must(err, "Could not get maxmind data from url")
 	geo := geoannotator.New(mainCtx, p, localIPs)
@@ -132,10 +143,6 @@ func main() {
 	}()
 
 	if *eventsocket.Filename != "" {
-		// Load the siteinfo annotations for "site" specific metadata.
-		js, err := content.FromURL(mainCtx, siteinfo.URL)
-		rtx.Must(err, "Could not load siteinfo URL")
-		site := siteannotator.New(mainCtx, mlabHostname, js, localIPs)
 
 		// Generate .json files for every UUID discovered.
 		h := handler.New(*datadir, *eventbuffersize, []annotator.Annotator{geo, asn, site})

--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func main() {
 	// managed instance group's load balancer to localIPs. If uuid-annotator
 	// does not know about the public IP of the load balancer, then it will fail
 	// to annotate anything because it doesn't recognize its own public address
-	// in either the Src of Dest of incoming tcp-info events.
+	// in either the Src or Dest of incoming tcp-info events.
 	js, err := content.FromURL(mainCtx, siteinfo.URL)
 	rtx.Must(err, "Could not load siteinfo URL")
 	site, localIPs := siteannotator.New(mainCtx, mlabHostname, js, localIPs)

--- a/testdata/annotations.json
+++ b/testdata/annotations.json
@@ -46,6 +46,23 @@
       },
       "Type": "virtual"
    },
+   "mlab1-six06.mlab-sandbox.measurement-lab.org": {
+      "Annotation": {
+         "Geo": {
+            "City": "New York"
+         },
+         "Machine": "mlab1",
+         "Network": {
+            "ASName": "TATA COMMUNICATIONS (AMERICA) INC"
+         },
+         "Site": "six06"
+      },
+      "Network": {
+         "IPv4": "64.86.148.129/32",
+         "IPv6": "2001:5a0:4300::/64"
+      },
+      "Type": "virtual"
+   },
    "mlab1-six01.mlab-sandbox.measurement-lab.org": {
       "Annotation": {
          "Geo": {


### PR DESCRIPTION
Virtual machines will be part of managed instance groups, which sit behind a pass-through TCP load balancer. In such cases, packets arriving to the machine from the load balancer will have a destination address of the load balancer's public IP, which is not a local address on the machine. Without these changes uuid-annotator will refuse to annoate a connection, since it doesn't recognize either the Src of Dest IP address as being its own (annotate.FindDirection() fails). These changes cause siteannotator.New() to append the public IP address from siteinfo to localIPs if it is a virtual machine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/uuid-annotator/55)
<!-- Reviewable:end -->
