### PR TITLE
Creates -datadir immediately on startup

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -34,7 +34,7 @@ func (j *job) WriteFile(dir string, data *annotator.Annotations) error {
 
 	// Create the necessary subdirectories.
 	dir = dir + j.timestamp.Format("/2006/01/02/")
-	err = fs.MkdirAll(dir, 0777)
+	err = fs.MkdirAll(dir, 0755)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"log"
 	"net"
+	"os"
 	"sync"
 	"time"
 
@@ -71,6 +72,10 @@ func findLocalIPs(localAddrs []net.Addr) []net.IP {
 func main() {
 	flag.Parse()
 	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Could not get args from environment variables")
+
+	// Create the datatype directory immediately, since pusher will crash
+	// without it.
+	rtx.Must(os.MkdirAll(*datadir, 0755), "Could not create datatype dir %s", datadir)
 
 	// Parse the node's name into its constituent parts. This ensures that the
 	// value of the -hostname flag is actually valid. Additionally, virtual


### PR DESCRIPTION
Currently, the value of the flag -datadir is only created when uuid-annotator goes to write the first annotation file. If uuid-annotator is running in a pod that doesn't get sufficient traffic which would cause tcp-info to generate an event, then the datatype directory will not be created. However, pusher will crashloop until this directory exists. This commit causes uuid-annotator to create the datatype directory immediately upon startup.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/uuid-annotator/56)
<!-- Reviewable:end -->
