### PR TITLE
Append IPv6 address to localIPs

### DIFF
--- a/siteannotator/server.go
+++ b/siteannotator/server.go
@@ -124,10 +124,10 @@ func (g *siteAnnotator) load(ctx context.Context, localIPs []net.IP) (*annotator
 		if err != nil {
 			return nil, nil, err
 		}
-		// If this is a virtual site, append the site's public IP address to
-		// localIPs. The public address of the load balancer is not known on any
-		// interface on the machine. Without adding it to localIPs,
-		// uuid-annotator will fail to recognize its own public address in
+		// If this is a virtual site, append the site's public IP addresses to
+		// localIPs. The public addresses of the load balancer are not known on
+		// any interface on the machine. Without adding them to localIPs,
+		// uuid-annotator will fail to recognize its own public addresses in
 		// either the Src or Dest fields of incoming tcp-info events, and will
 		// fail to annotate anything.
 		if v.Type == "virtual" {

--- a/siteannotator/server.go
+++ b/siteannotator/server.go
@@ -131,11 +131,9 @@ func (g *siteAnnotator) load(ctx context.Context, localIPs []net.IP) (*annotator
 		// either the Src or Dest fields of incoming tcp-info events, and will
 		// fail to annotate anything.
 		if v.Type == "virtual" {
-			// Ignore IPNet and error, since parseCIDR() above has already
-			// validated the IP addresses.
-			ip, _, _ := net.ParseCIDR(v.Network.IPv4)
-			localIPs = append(localIPs, ip)
+			localIPs = append(localIPs, g.v4.IP, g.v6.IP)
 		}
+
 		return &v.Annotation, localIPs, nil
 	}
 	return nil, nil, ErrHostnameNotFound

--- a/siteannotator/server_test.go
+++ b/siteannotator/server_test.go
@@ -289,7 +289,7 @@ func Test_srvannotator_load(t *testing.T) {
 					ASName: "TATA COMMUNICATIONS (AMERICA) INC",
 				},
 			},
-			wantLocalIPs: append(testLocalIPs, net.ParseIP("64.86.148.129")),
+			wantLocalIPs: append(testLocalIPs, net.ParseIP("64.86.148.129").To4(), net.ParseIP("2001:5a0:4300::")),
 		},
 		{
 			name:     "error-bad-ipv4",


### PR DESCRIPTION
GCP VMs do not have their public IP addresses configured on local interfaces. uuid-annotator need to be able to identify whether the server or client was the source of a particular TCP flow, and uses the addresses it finds on the local interface to help determine this. There was already a bit of code to append the IPv4 address of a VM to the `localIPs` variable, and this PR just adds the IPv6 address too.

Additionally, instead of calling `net.ParseCIDR()` a second time, just use the `net.IPNet` values already provided by `parseCIDR` earlier in the same function.

Fixes a unit test to expect an IPv6 address, and  converts the appended IPv4 address to a 4-byte representation to match was is actually appended to `localIPs`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/uuid-annotator/63)
<!-- Reviewable:end -->
