### PR TITLE
Add IPv4 only annotator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ script:
 - go build ./...
 - go test ./... -cover=1 -coverprofile=_c.cov
 - go test ./... -race
-- $GOPATH/bin/goveralls -service=travis-ci -coverprofile=_c.cov
+- $GOPATH/bin/goveralls -service=travis-pro -coverprofile=_c.cov

--- a/asnannotator/asn_test.go
+++ b/asnannotator/asn_test.go
@@ -305,3 +305,41 @@ func TestNewFake(t *testing.T) {
 		t.Error("Should have had a missing return value, not", n3)
 	}
 }
+
+func Test_IPv4Annotator_AnnotateIP(t *testing.T) {
+	setUp()
+	tests := []struct {
+		name string
+		addr string
+		want annotator.Network
+	}{
+		{
+			name: "success-ipv4",
+			addr: "1.0.0.1",
+			want: annotator.Network{
+				CIDR:     "1.0.0.0/24",
+				ASNumber: 13335,
+				Systems: []annotator.System{
+					{ASNs: []uint32{13335}},
+				},
+			},
+		},
+		{
+			name: "success-ipv6",
+			addr: "2001:200::1",
+			want: annotator.Network{
+				Missing: true,
+			},
+		},
+	}
+	ctx := context.Background()
+	a := NewIPv4(ctx, local4Rawfile)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := a.AnnotateIP(tt.addr)
+			if diff := deep.Equal(*got, tt.want); diff != nil {
+				t.Error("AnnotateIP() wrong value; got!=want", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds minimal changes to allow reuse of the asnannotator package for IPv4 only lookups.

This change would allow the autojoin API to use the package directly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/uuid-annotator/64)
<!-- Reviewable:end -->
