### PR TITLE
Use the whole provided hostname for siteinfo lookup

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func main() {
 	// https://siteinfo.mlab-oti.measurementlab.net/v2/sites/annotations.json
 	h, err := host.Parse(*hostname)
 	rtx.Must(err, "Failed to parse the provided hostname")
-	mlabHostname := h.String()
+	mlabHostname := h.StringWithService()
 
 	defer mainCancel()
 	// A waitgroup that waits for every component goroutine to complete before main exits.


### PR DESCRIPTION
This replaces `host.String()` with `host.StringWithService()` so that v3 hostnames (`<service>-<metro><asn>-<ipv4>...`) can work.

In our daemonset templates uuid-annotator is passed `MLAB_NODE_NAME` which does not include the service name, so this change shouldn't affect uuid-annotator's typical usage while enabling BYOS hostnames.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/uuid-annotator/67)
<!-- Reviewable:end -->
