### PR TITLE
Update -hostname flag to use flagx.StringFile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/go-test/deep v1.0.6
-	github.com/m-lab/go v0.1.73
+	github.com/m-lab/go v0.1.75
 	github.com/m-lab/tcp-info v1.5.3
 	github.com/oschwald/geoip2-golang v1.7.0
 	github.com/prometheus/client_golang v1.12.2

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,8 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/m-lab/go v0.1.73 h1:vy4MRcEyvYOhfA55V6tT/NZlrfWS0qTNJktIrLaAbmw=
-github.com/m-lab/go v0.1.73/go.mod h1:BirARfHWjjXHaCGNyWCm/CKW1OarjuEj8Yn6Z2rc0M4=
+github.com/m-lab/go v0.1.75 h1:t4kvig26aUBznA0b3e997Jn0BjELAOKpO1xILWp2VJs=
+github.com/m-lab/go v0.1.75/go.mod h1:BirARfHWjjXHaCGNyWCm/CKW1OarjuEj8Yn6Z2rc0M4=
 github.com/m-lab/tcp-info v1.5.3 h1:4IspTPcNc8D8LNRvuFnID8gDiz+hxPAtYvpKZaiGGe8=
 github.com/m-lab/tcp-info v1.5.3/go.mod h1:bkvI4qbjB6QVC2tsLSHqf5OnIYcmuLEVjo7+8YA56Kg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=

--- a/main.go
+++ b/main.go
@@ -27,8 +27,7 @@ import (
 
 var (
 	datadir         = flag.String("datadir", ".", "The directory to put the data in")
-	hostname        = flag.String("hostname", "", "The server hostname, used to lookup server siteinfo annotations")
-	hostnameFile    = flagx.FileBytes{}
+	hostname        = flagx.StringFile{}
 	maxmindurl      = flagx.URL{}
 	routeviewv4     = flagx.URL{}
 	routeviewv6     = flagx.URL{}
@@ -50,7 +49,7 @@ var (
 )
 
 func init() {
-	flag.Var(&hostnameFile, "hostname-file", "The file containing the server hostname.")
+	flag.Var(&hostname, "hostname", "Server hostname to lookup annotations, may be read from file with @<file>")
 	flag.Var(&maxmindurl, "maxmind.url", "The URL for the file containing MaxMind IP metadata.  Accepted URL schemes currently are: gs://bucket/file and file:./relativepath/file")
 	flag.Var(&routeviewv4, "routeview-v4.url", "The URL for the RouteViewIPv4 file containing ASN metadata. gs:// and file:// schemes accepted.")
 	flag.Var(&routeviewv6, "routeview-v6.url", "The URL for the RouteViewIPv6 file containing ASN metadata. gs:// and file:// schemes accepted.")
@@ -75,11 +74,6 @@ func main() {
 	flag.Parse()
 	rtx.Must(flagx.ArgsFromEnv(flag.CommandLine), "Could not get args from environment variables")
 
-	// If -hostname-file was set, use it instead of -hostname.
-	if hostnameFile.String() != "" {
-		*hostname = hostnameFile.String()
-	}
-
 	// Create the datatype directory immediately, since pusher will crash
 	// without it.
 	rtx.Must(os.MkdirAll(*datadir, 0755), "Could not create datatype dir %s", datadir)
@@ -93,7 +87,7 @@ func main() {
 	// annotations.json:
 	//
 	// https://siteinfo.mlab-oti.measurementlab.net/v2/sites/annotations.json
-	h, err := host.Parse(*hostname)
+	h, err := host.Parse(hostname.Value)
 	rtx.Must(err, "Failed to parse the provided hostname")
 	mlabHostname := h.StringWithService()
 

--- a/main_test.go
+++ b/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"net"
 	"os"
 	"reflect"
@@ -15,49 +14,66 @@ import (
 )
 
 func TestMainSmokeTest(t *testing.T) {
-	// Set up the local HD.
-	dir, err := ioutil.TempDir("", "TestMain")
-	rtx.Must(err, "Could not create tempdir")
-	defer os.RemoveAll(dir)
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{
+			name:  "hostname-literal",
+			value: "mlab1-lga03.mlab-sandbox.measurement-lab.org",
+		},
+		{
+			name:  "hostname-file",
+			value: "@./testdata/hostname",
+		},
+	}
 
-	// We need two contexts, one for the test and one for main. We need the test
-	// context to outlive main's context, because we don't want the cancellation
-	// of main to cause the cancellation of the tcpinfo.eventsocket, because
-	// then the shutdown of main() will race the shutdown of the local
-	// tcpinfo.eventsocket.Server, and when the tcpinfo.eventsocket.Server shuts
-	// down first then main (correctly) exits with an error and the test fails.
-	testCtx, testCancel := context.WithCancel(context.Background())
-	defer testCancel()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up the local HD.
+			dir, err := os.MkdirTemp("", "TestMain")
+			rtx.Must(err, "Could not create tempdir")
+			defer os.RemoveAll(dir)
+			// We need two contexts, one for the test and one for main. We need the test
+			// context to outlive main's context, because we don't want the cancellation
+			// of main to cause the cancellation of the tcpinfo.eventsocket, because
+			// then the shutdown of main() will race the shutdown of the local
+			// tcpinfo.eventsocket.Server, and when the tcpinfo.eventsocket.Server shuts
+			// down first then main (correctly) exits with an error and the test fails.
+			testCtx, testCancel := context.WithCancel(context.Background())
+			defer testCancel()
 
-	// Set up global variables.
-	mainCtx, mainCancel = context.WithCancel(testCtx)
-	mainRunning = make(chan struct{}, 1)
-	*eventsocket.Filename = dir + "/eventsocket.sock"
-	*ipservice.SocketFilename = dir + "/ipannotator.sock"
-	rtx.Must(maxmindurl.Set("file:./testdata/fake.tar.gz"), "Failed to set maxmind url for testing")
-	rtx.Must(routeviewv4.Set("file:./testdata/RouteViewIPv4.tiny.gz"), "Failed to set routeview v4 url for testing")
-	rtx.Must(routeviewv6.Set("file:./testdata/RouteViewIPv6.tiny.gz"), "Failed to set routeview v6 url for testing")
-	rtx.Must(asnameurl.Set("file:./data/asnames.ipinfo.csv"), "Failed to set ipinfo ASName url for testing")
-	rtx.Must(siteinfo.Set("file:./testdata/annotations.json"), "Failed to set siteinfo annotations url for testing")
-	*hostname = "mlab1-lga03.mlab-sandbox.measurement-lab.org"
+			// Set up global variables.
+			mainCtx, mainCancel = context.WithCancel(testCtx)
+			mainRunning = make(chan struct{}, 1)
+			*eventsocket.Filename = dir + "/eventsocket.sock"
+			*ipservice.SocketFilename = dir + "/ipannotator.sock"
+			rtx.Must(maxmindurl.Set("file:./testdata/fake.tar.gz"), "Failed to set maxmind url for testing")
+			rtx.Must(routeviewv4.Set("file:./testdata/RouteViewIPv4.tiny.gz"), "Failed to set routeview v4 url for testing")
+			rtx.Must(routeviewv6.Set("file:./testdata/RouteViewIPv6.tiny.gz"), "Failed to set routeview v6 url for testing")
+			rtx.Must(asnameurl.Set("file:./data/asnames.ipinfo.csv"), "Failed to set ipinfo ASName url for testing")
+			rtx.Must(siteinfo.Set("file:./testdata/annotations.json"), "Failed to set siteinfo annotations url for testing")
+			os.Setenv("HOSTNAME", tt.value)
 
-	// Now start up a fake eventsocket.
-	srv := eventsocket.New(*eventsocket.Filename)
-	rtx.Must(srv.Listen(), "Could not listen")
-	go srv.Serve(testCtx)
+			// Now start up a fake eventsocket.
+			srv := eventsocket.New(*eventsocket.Filename)
+			rtx.Must(srv.Listen(), "Could not listen")
+			go srv.Serve(testCtx)
 
-	// Cancel main after main has been running all its goroutines for half a
-	// second.
-	go func() {
-		<-mainRunning
-		// Give all of main's goroutines a little time to start now that we know
-		// main() has started them all.
-		time.Sleep(500 * time.Millisecond)
-		mainCancel()
-	}()
+			// Cancel main after main has been running all its goroutines for half a
+			// second.
+			go func() {
+				<-mainRunning
+				// Give all of main's goroutines a little time to start now that we know
+				// main() has started them all.
+				time.Sleep(500 * time.Millisecond)
+				mainCancel()
+			}()
 
-	// Run main. Full coverage, no crash, and return == success!
-	main()
+			// Run main. Full coverage, no crash, and return == success!
+			main()
+		})
+	}
 }
 
 func Test_findLocalIPs(t *testing.T) {

--- a/testdata/hostname
+++ b/testdata/hostname
@@ -1,0 +1,1 @@
+mlab1-lga03.mlab-sandbox.measurement-lab.org


### PR DESCRIPTION
This change updates the `-hostname` flag to use flagx.StringFile so a single flag can provide the hostname literal or read it from a file. Users of the `-hostname-file` flag must be updated to use `-hostname=@path/file`. The autonode is the only known use case: https://github.com/m-lab/autonode/blob/main/examples/ndt-fullstack.yml

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/uuid-annotator/68)
<!-- Reviewable:end -->
